### PR TITLE
[spring boot]

### DIFF
--- a/react-view/src/App.jsx
+++ b/react-view/src/App.jsx
@@ -1,21 +1,40 @@
 import logo from './logo.svg';
 import './App.css';
-import {BrowserRouter, Route, Router, Switch} from "react-router-dom";
+import {BrowserRouter, Redirect, Route, Router, Switch} from "react-router-dom";
 import ItemsMain from "./items/ItemsMain";
-import {Component} from "react";
+import {Component, useEffect, useState} from "react";
 import AdminMain from "./admin/AdminMain";
+import RedirectLogin from "./authorization/RedirectLogin"
+import {domain} from "./constant/Constant";
 
 const App = () => {
 
+  const [auth, setAuth] = useState(false);
+
+  //서버에서 로드할건지 정보 전달
+  useEffect(() => {
+    const currentURL = window.location.href;
+    const uri = new URL(currentURL).pathname;
+
+    fetch("/auth?uri=" + uri)
+      .then(response => {
+        if (!response.ok) {
+          window.location.href = domain + "/login?requestURI=" + uri;
+          return
+        }
+        setAuth(true);
+      });
+  }, []);
 
 
-  return (
-    <BrowserRouter>
-      <Switch>
-        <Route path={"/admin/items"} exact component={ItemsMain}/>
-        <Route path={"/admin"} exact component={AdminMain}/>
-      </Switch>
-    </BrowserRouter>
+  return (auth ?
+      <BrowserRouter>
+        <Switch>
+          <Route path={"/admin/items"} exact component={ItemsMain}/>
+          <Route path={"/admin"} exact component={AdminMain}/>
+          <Redirect to={"/login"} exact componet={RedirectLogin}/>
+        </Switch>
+      </BrowserRouter> : null
   );
 }
 

--- a/src/main/java/com/yet/project/AppConfig.java
+++ b/src/main/java/com/yet/project/AppConfig.java
@@ -2,7 +2,10 @@ package com.yet.project;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yet.project.web.argumentresolver.LoginArgumentResolver;
+import com.yet.project.web.interceptor.AddPatternConstant;
+import com.yet.project.web.interceptor.ExcludePatternConstant;
 import com.yet.project.web.interceptor.LoginInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -13,7 +16,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class AppConfig implements WebMvcConfigurer {
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     RestTemplate restTemplate() {
@@ -23,10 +29,13 @@ public class AppConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor())
-            .order(1)
-            .addPathPatterns("/admin/**")
-            .excludePathPatterns("/css/**", "/*.ico", "/error", "/bootstrap/**", "/images/**", "/login/**", "/");
+        List<String> pathPatterns = AddPatternConstant.getList();
+        List<String> excludePathPatterns = ExcludePatternConstant.getList();
+
+        registry.addInterceptor(new LoginInterceptor(objectMapper))
+                .order(1)
+                .addPathPatterns(pathPatterns)
+                .excludePathPatterns(excludePathPatterns);
     }
 
     @Override

--- a/src/main/java/com/yet/project/domain/service/login/AntMatcher.java
+++ b/src/main/java/com/yet/project/domain/service/login/AntMatcher.java
@@ -1,0 +1,10 @@
+package com.yet.project.domain.service.login;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+
+
+@Component
+public class AntMatcher extends AntPathMatcher {
+
+}

--- a/src/main/java/com/yet/project/domain/service/user/UserService.java
+++ b/src/main/java/com/yet/project/domain/service/user/UserService.java
@@ -2,20 +2,25 @@ package com.yet.project.domain.service.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yet.project.domain.service.login.AntMatcher;
 import com.yet.project.domain.service.login.LoginAuth;
 import com.yet.project.domain.user.UserKakao;
 import com.yet.project.domain.user.User;
 import com.yet.project.domain.user.UserSocialLogin;
 import com.yet.project.repository.dao.user.UserDao;
 import com.yet.project.web.dto.login.*;
+import com.yet.project.web.interceptor.AddPatternConstant;
+import com.yet.project.web.sessionconst.SessionConst;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import javax.servlet.http.HttpSession;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +34,7 @@ public class UserService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final LoginAuth loginAuth;
+    private final AntMatcher antMatcher;
 
     public void userJoin(BasicJoinForm join) {
         User user = new User();
@@ -149,4 +155,22 @@ public class UserService {
         User user = loginAuth.authUserByLoginForm(form);
         return user;
     }
+
+    public boolean authenticateReactURI(HttpSession session, String uri) {
+        //인증 실패
+        if (session == null || session.getAttribute(SessionConst.LOGIN_MEMBER) == null){
+            List<String> patterns = AddPatternConstant.getList();
+            for (String p : patterns) {
+                if (antMatcher.match(p, uri)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+
+
+        return true;
+    }
+
 }

--- a/src/main/java/com/yet/project/web/controller/login/ReactAuthController.java
+++ b/src/main/java/com/yet/project/web/controller/login/ReactAuthController.java
@@ -1,0 +1,37 @@
+package com.yet.project.web.controller.login;
+
+import com.yet.project.domain.service.item.ItemService;
+import com.yet.project.domain.service.login.LoginService;
+import com.yet.project.domain.service.user.UserService;
+import com.yet.project.web.dto.login.AuthError;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.Session;
+import org.apache.catalina.connector.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpSession;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ReactAuthController {
+
+    private final UserService userService;
+
+    @GetMapping(value = "/auth", headers = {"referer"})
+    public ResponseEntity authenticateReactPath(@RequestParam String uri, HttpSession session) {
+        log.info("uri === {}", uri);
+        if (userService.authenticateReactURI(session, uri)) {
+            return ResponseEntity.ok().build();
+        }
+        AuthError authError = new AuthError(HttpStatus.UNAUTHORIZED.value(), "", uri);
+        return new ResponseEntity<>(authError, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/yet/project/web/dto/login/AuthError.java
+++ b/src/main/java/com/yet/project/web/dto/login/AuthError.java
@@ -1,0 +1,12 @@
+package com.yet.project.web.dto.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthError {
+    Integer code;
+    String message;
+    String requestURI;
+}

--- a/src/main/java/com/yet/project/web/interceptor/AddPatternConstant.java
+++ b/src/main/java/com/yet/project/web/interceptor/AddPatternConstant.java
@@ -1,0 +1,28 @@
+package com.yet.project.web.interceptor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum AddPatternConstant {
+    ADMIN("/admin/**"),
+    ;
+
+    private final String uri;
+
+    AddPatternConstant(String uri) {
+        this.uri = uri;
+    }
+
+    public static AddPatternConstant getInstance() {
+        return ADMIN;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public static List<String> getList() {
+        return Arrays.stream(values()).map(AddPatternConstant::getUri).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/yet/project/web/interceptor/ExcludePatternConstant.java
+++ b/src/main/java/com/yet/project/web/interceptor/ExcludePatternConstant.java
@@ -1,0 +1,29 @@
+package com.yet.project.web.interceptor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum ExcludePatternConstant {
+    CSS("/css/**"),
+    ICON("/*.ico"),
+    ERROR("/error"),
+    BOOTSTRAP("/bootstrap/**"),
+    IMAGES("/images/**"),
+    LOGIN("/login/**"),
+    LEST("/");
+
+    private final String uri;
+
+    ExcludePatternConstant(String uri) {
+        this.uri = uri;
+    }
+
+    public String value() {
+        return uri;
+    }
+
+    public static List<String> getList() {
+        return Arrays.stream(values()).map(ExcludePatternConstant::value).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/yet/project/web/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/yet/project/web/interceptor/LoginInterceptor.java
@@ -1,8 +1,15 @@
 package com.yet.project.web.interceptor;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yet.project.domain.service.user.UserService;
+import com.yet.project.web.dto.login.AuthError;
 import com.yet.project.web.sessionconst.SessionConst;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
@@ -10,9 +17,13 @@ import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import java.util.Enumeration;
 
 @Slf4j
+@RequiredArgsConstructor
 public class LoginInterceptor implements HandlerInterceptor {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -20,13 +31,19 @@ public class LoginInterceptor implements HandlerInterceptor {
         log.info("인증 체크 인터셉터 실행 {}", requestURI);
         HttpSession session = request.getSession(false);
         if (session == null || session.getAttribute(SessionConst.LOGIN_MEMBER) == null) {
-            log.info("미인증 사용자 요청");
-            response.sendRedirect("/login?requestURI=" + requestURI);
-            StringBuffer requestURL = request.getRequestURL();
-            log.info("requestURL {}", requestURL);
-            log.info("/login?requestURI=" + requestURI);
-            log.info("referer {}", request.getHeader("referer"));
-            return false;
+            log.error("미인증 사용자 요청");
+            if (request.getHeader("referer") == null) {
+                response.sendRedirect("/login?requestURI=" + requestURI);
+                return false;
+            } else {
+                AuthError authError = new AuthError(HttpStatus.UNAUTHORIZED.value(), "noneAuthorize", requestURI);
+
+                response.setContentType("application/json");
+                response.getWriter().write(objectMapper.writeValueAsString(authError));
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+                return false;
+            }
         }
         return true;
     }

--- a/src/test/java/com/yet/project/service/UserServiceTest.java
+++ b/src/test/java/com/yet/project/service/UserServiceTest.java
@@ -1,18 +1,41 @@
 package com.yet.project.service;
 
+import com.yet.project.domain.service.login.AntMatcher;
 import com.yet.project.repository.dao.user.UserDao;
 import com.yet.project.domain.user.User;
+import com.yet.project.web.interceptor.AddPatternConstant;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.AntPathMatcher;
 
+import java.util.Arrays;
+
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 class UserServiceTest {
     @Autowired
     UserDao userService;
+    @Autowired
+    AntMatcher antMatcher;
 
     @Test
     void getUserById() {
+        boolean match = antMatcher.match("/admin/**", "/admin");
+        System.out.println("match = " + match);
+        AJ.assertThat(match).isEqualTo(true);
+    }
+
+    @Test
+    void enumTest() {
+        String name = AddPatternConstant.ADMIN.name();
+        System.out.println("name = " + name);
+        String uri = AddPatternConstant.ADMIN.getUri();
+        System.out.println("uri = " + uri);
     }
 
 


### PR DESCRIPTION
react에서 온 요청과 template engine에서 온 정보를 구문 할 수 있또록 Interceptor에서 권한 처리할때 header 정보에 따라 다르게 처리

권한을 만족하는지 확인하는 메서드, 권한이 유효한지 url을 받을 수 있는 전용 컨트롤러와 그 메서드 생성

기존 Interceptor에서 사용하는 변수와 메서드를 새로 만든 컨트롤러에서도 사용할 수 있도록 공용화

[react]
권한이 없으면 더이상 정보를 요청하지 않고 데이터를 렌더링 하지 않도록 로그인화면으로 redirect 처리